### PR TITLE
Add test for ensuring correct management of dataset tags is possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,7 @@
 - Replace npm with yarn.
 - Add liveliness and readiness probes.
 - Add resource quota definition for kubernetes.
+
+# 26/11/2019
+
+- Add tests for ensuring the correct management of dataset tags (related to https://www.pivotaltracker.com/n/projects/1883443/stories/169420749).

--- a/app/src/services/graph.service.js
+++ b/app/src/services/graph.service.js
@@ -17,9 +17,7 @@ class GraphService {
                 }
             });
         } catch (e) {
-            const errorMsg = '[GraphService]: Error communicating with Graph MS (POST associations)';
-            logger.error(errorMsg, e.message);
-            throw new ConsistencyViolation(errorMsg);
+            throw new ConsistencyViolation('[GraphService]: Error communicating with Graph MS (POST associations)');
         }
     }
 
@@ -36,9 +34,7 @@ class GraphService {
                 }
             });
         } catch (e) {
-            const errorMsg = '[GraphService]: Error communicating with Graph MS (PUT associations)';
-            logger.error(errorMsg, e.message);
-            throw new ConsistencyViolation(errorMsg);
+            throw new ConsistencyViolation('[GraphService]: Error communicating with Graph MS (PUT associations)');
         }
     }
 
@@ -55,9 +51,7 @@ class GraphService {
                 json: true
             });
         } catch (e) {
-            const errorMsg = '[GraphService]: Error communicating with Graph MS (DELETE associations)';
-            logger.error(errorMsg, e.message);
-            throw new ConsistencyViolation(errorMsg);
+            throw new ConsistencyViolation('[GraphService]: Error communicating with Graph MS (DELETE associations)');
         }
     }
 

--- a/app/src/services/graph.service.js
+++ b/app/src/services/graph.service.js
@@ -1,5 +1,6 @@
 const logger = require('logger');
 const ctRegisterMicroservice = require('sd-ct-register-microservice-node');
+const ConsistencyViolation = require('errors/consistency-violation.error');
 
 class GraphService {
 
@@ -16,8 +17,9 @@ class GraphService {
                 }
             });
         } catch (e) {
-            logger.error(e);
-            throw new Error(e);
+            const errorMsg = '[GraphService]: Error communicating with Graph MS (POST associations)';
+            logger.error(errorMsg, e.message);
+            throw new ConsistencyViolation(errorMsg);
         }
     }
 
@@ -34,8 +36,9 @@ class GraphService {
                 }
             });
         } catch (e) {
-            logger.error(e);
-            throw new Error(e);
+            const errorMsg = '[GraphService]: Error communicating with Graph MS (PUT associations)';
+            logger.error(errorMsg, e.message);
+            throw new ConsistencyViolation(errorMsg);
         }
     }
 
@@ -52,8 +55,9 @@ class GraphService {
                 json: true
             });
         } catch (e) {
-            logger.error(e);
-            throw new Error(e);
+            const errorMsg = '[GraphService]: Error communicating with Graph MS (DELETE associations)';
+            logger.error(errorMsg, e.message);
+            throw new ConsistencyViolation(errorMsg);
         }
     }
 

--- a/app/src/services/relationship.service.js
+++ b/app/src/services/relationship.service.js
@@ -154,7 +154,19 @@ class RelationshipService {
                 }
             }
             logger.debug(`Tags to vocabulary`);
-            vocabulary.resources[position].tags = body.tags;
+
+            // If the resource has not been found in the vocabulary resources, push it!
+            if (position === undefined) {
+                vocabulary.resources.push({
+                    id: resource.id,
+                    dataset,
+                    type: resource.type,
+                    tags: body.tags,
+                });
+            } else {
+                vocabulary.resources[position].tags = body.tags;
+            }
+
             vocabulary.save();
         } catch (err) {
             throw err;

--- a/app/test/e2e/utils.js
+++ b/app/test/e2e/utils.js
@@ -240,13 +240,13 @@ const mockDeleteGraphAssociation = (datasetId, application = 'rw', mockSuccess =
         .reply(mockSuccess ? 200 : 404, { data: {} });
 };
 
-const assert401 = (response) => {
+const assertUnauthorizedResponse = (response) => {
     response.status.should.equal(401);
     response.body.should.have.property('errors').and.be.an('array');
     response.body.errors[0].should.have.property('detail').and.equal('Unauthorized');
 };
 
-const assert200 = (response, length = undefined) => {
+const assertOKResponse = (response, length = undefined) => {
     response.status.should.equal(200);
     response.body.should.have.property('data').and.be.an('array');
     if (length) {
@@ -255,8 +255,8 @@ const assert200 = (response, length = undefined) => {
 };
 
 module.exports = {
-    assert200,
-    assert401,
+    assertOKResponse,
+    assertUnauthorizedResponse,
     createResource,
     createVocabulary,
     mockDataset,

--- a/app/test/e2e/utils.js
+++ b/app/test/e2e/utils.js
@@ -222,19 +222,19 @@ const mockLayer = (id = undefined, extraData = {}) => {
     return mockData;
 };
 
-const mockPostGraphAssocition = (id, mockSuccess = true) => {
+const mockPostGraphAssociation = (id, mockSuccess = true) => {
     nock(process.env.CT_URL)
         .post(`/v1/graph/dataset/${id}/associate`)
         .reply(mockSuccess ? 200 : 404, { data: {} });
 };
 
-const mockPutGraphAssocition = (id, mockSuccess = true) => {
+const mockPutGraphAssociation = (id, mockSuccess = true) => {
     nock(process.env.CT_URL)
         .put(`/v1/graph/dataset/${id}/associate`)
         .reply(mockSuccess ? 200 : 404, { data: {} });
 };
 
-const mockDeleteGraphAssocition = (id, application = 'rw', mockSuccess = true) => {
+const mockDeleteGraphAssociation = (id, application = 'rw', mockSuccess = true) => {
     nock(process.env.CT_URL)
         .delete(`/v1/graph/dataset/${id}/associate?application=${application}`)
         .reply(mockSuccess ? 200 : 404, { data: {} });
@@ -260,9 +260,9 @@ module.exports = {
     createResource,
     createVocabulary,
     mockDataset,
-    mockDeleteGraphAssocition,
-    mockPostGraphAssocition,
-    mockPutGraphAssocition,
+    mockDeleteGraphAssociation,
+    mockPostGraphAssociation,
+    mockPutGraphAssociation,
     mockLayer,
     mockWidget,
 };

--- a/app/test/e2e/utils.js
+++ b/app/test/e2e/utils.js
@@ -240,7 +240,23 @@ const mockDeleteGraphAssocition = (id, application = 'rw', mockSuccess = true) =
         .reply(mockSuccess ? 200 : 404, { data: {} });
 };
 
+const assert401 = (response) => {
+    response.status.should.equal(401);
+    response.body.should.have.property('errors').and.be.an('array');
+    response.body.errors[0].should.have.property('detail').and.equal('Unauthorized');
+};
+
+const assert200 = (response, length = undefined) => {
+    response.status.should.equal(200);
+    response.body.should.have.property('data').and.be.an('array');
+    if (length) {
+        response.body.should.have.property('data').and.be.an('array').and.have.lengthOf(length);
+    }
+};
+
 module.exports = {
+    assert200,
+    assert401,
     createResource,
     createVocabulary,
     mockDataset,

--- a/app/test/e2e/utils.js
+++ b/app/test/e2e/utils.js
@@ -222,10 +222,31 @@ const mockLayer = (id = undefined, extraData = {}) => {
     return mockData;
 };
 
+const mockPostGraphAssocition = (id, mockSuccess = true) => {
+    nock(process.env.CT_URL)
+        .post(`/v1/graph/dataset/${id}/associate`)
+        .reply(mockSuccess ? 200 : 404, { data: {} });
+};
+
+const mockPutGraphAssocition = (id, mockSuccess = true) => {
+    nock(process.env.CT_URL)
+        .put(`/v1/graph/dataset/${id}/associate`)
+        .reply(mockSuccess ? 200 : 404, { data: {} });
+};
+
+const mockDeleteGraphAssocition = (id, application = 'rw', mockSuccess = true) => {
+    nock(process.env.CT_URL)
+        .delete(`/v1/graph/dataset/${id}/associate?application=${application}`)
+        .reply(mockSuccess ? 200 : 404, { data: {} });
+};
+
 module.exports = {
     createResource,
     createVocabulary,
     mockDataset,
+    mockDeleteGraphAssocition,
+    mockPostGraphAssocition,
+    mockPutGraphAssocition,
     mockLayer,
     mockWidget,
 };

--- a/app/test/e2e/utils.js
+++ b/app/test/e2e/utils.js
@@ -222,21 +222,21 @@ const mockLayer = (id = undefined, extraData = {}) => {
     return mockData;
 };
 
-const mockPostGraphAssociation = (id, mockSuccess = true) => {
+const mockPostGraphAssociation = (datasetId, mockSuccess = true) => {
     nock(process.env.CT_URL)
-        .post(`/v1/graph/dataset/${id}/associate`)
+        .post(`/v1/graph/dataset/${datasetId}/associate`)
         .reply(mockSuccess ? 200 : 404, { data: {} });
 };
 
-const mockPutGraphAssociation = (id, mockSuccess = true) => {
+const mockPutGraphAssociation = (datasetId, mockSuccess = true) => {
     nock(process.env.CT_URL)
-        .put(`/v1/graph/dataset/${id}/associate`)
+        .put(`/v1/graph/dataset/${datasetId}/associate`)
         .reply(mockSuccess ? 200 : 404, { data: {} });
 };
 
-const mockDeleteGraphAssociation = (id, application = 'rw', mockSuccess = true) => {
+const mockDeleteGraphAssociation = (datasetId, application = 'rw', mockSuccess = true) => {
     nock(process.env.CT_URL)
-        .delete(`/v1/graph/dataset/${id}/associate?application=${application}`)
+        .delete(`/v1/graph/dataset/${datasetId}/associate?application=${application}`)
         .reply(mockSuccess ? 200 : 404, { data: {} });
 };
 

--- a/app/test/e2e/vocabulary-dataset.spec.js
+++ b/app/test/e2e/vocabulary-dataset.spec.js
@@ -5,8 +5,8 @@ const Vocabulary = require('models/vocabulary.model');
 
 const { USERS } = require('./test.constants');
 const {
-    assert200,
-    assert401,
+    assertOKResponse,
+    assertUnauthorizedResponse,
     mockDataset,
     mockPostGraphAssociation,
     mockPutGraphAssociation,
@@ -34,7 +34,7 @@ describe('Vocabulary-dataset relationships test suite', () => {
     });
 
     it('Creating a vocab-dataset relationship without auth returns 401 Unauthorized', async () => {
-        assert401(await requester
+        assertUnauthorizedResponse(await requester
             .post(`/api/v1/dataset/123/vocabulary/science`)
             .send({ application: 'rw', tags: ['biology', 'chemistry'] }));
     });
@@ -52,7 +52,7 @@ describe('Vocabulary-dataset relationships test suite', () => {
             .post(`/api/v1/dataset/${mockDatasetId}/vocabulary/${vocabName}`)
             .send({ ...vocabData, loggedUser: USERS.ADMIN });
 
-        assert200(response);
+        assertOKResponse(response);
         response.body.data[0].should.have.property('id').and.equal(vocabName);
     });
 
@@ -75,7 +75,7 @@ describe('Vocabulary-dataset relationships test suite', () => {
             .patch(`/api/v1/dataset/${mockDatasetId}/vocabulary/${vocabName}`)
             .send({ ...vocabData2, loggedUser: USERS.ADMIN });
 
-        assert200(response);
+        assertOKResponse(response);
         response.body.data[0].should.have.property('id').and.equal(vocabName);
         response.body.data[0].attributes.should.have.property('application').and.equal(vocabData2.application);
         response.body.data[0].attributes.should.have.property('tags').and.deep.equal(vocabData2.tags);
@@ -94,7 +94,7 @@ describe('Vocabulary-dataset relationships test suite', () => {
                 loggedUser: USERS.ADMIN
             });
 
-        assert200(response);
+        assertOKResponse(response);
         response.body.data[0].attributes.should.have.property('name').and.equal('physics');
         response.body.data[0].attributes.should.have.property('application').and.equal('gfw');
         response.body.data[0].attributes.should.have.property('tags').and.deep.equal(['quantum', 'universe']);
@@ -122,11 +122,11 @@ describe('Vocabulary-dataset relationships test suite', () => {
         const response = await requester
             .delete(`/api/v1/dataset/${mockDatasetId}/vocabulary/${vocabName}?loggedUser=${JSON.stringify(USERS.ADMIN)}`).send();
 
-        assert200(response);
+        assertOKResponse(response);
     });
 
     it('Getting vocab-dataset relationships without auth returns 401 Unauthorized', async () => {
-        assert401(await requester.post(`/api/v1/dataset/123/vocabulary`).send());
+        assertUnauthorizedResponse(await requester.post(`/api/v1/dataset/123/vocabulary`).send());
     });
 
     it('Getting vocab-dataset relationships with auth returns 200 OK with the requested data', async () => {
@@ -149,7 +149,7 @@ describe('Vocabulary-dataset relationships test suite', () => {
             .post(`/api/v1/dataset/${mockDatasetId}/vocabulary`)
             .send({ loggedUser: USERS.ADMIN });
 
-        assert200(response);
+        assertOKResponse(response);
         response.body.data[0].attributes.should.have.property('name').and.equal('science_v3');
         response.body.data[0].attributes.should.have.property('application').and.equal('rw');
         response.body.data[0].attributes.should.have.property('tags').and.deep.equal(['biology', 'chemistry']);
@@ -165,7 +165,7 @@ describe('Vocabulary-dataset relationships test suite', () => {
             .get(`/api/v1/dataset/${mockDatasetId}/vocabulary`)
             .send({ loggedUser: USERS.ADMIN });
 
-        assert200(getResponse, 0);
+        assertOKResponse(getResponse, 0);
 
         // Use PUT to add a new vocabulary to the mock dataset
         const putData = {};
@@ -175,7 +175,7 @@ describe('Vocabulary-dataset relationships test suite', () => {
             .put(`/api/v1/dataset/${mockDatasetId}/vocabulary`)
             .send({ ...putData, loggedUser: USERS.ADMIN });
 
-        assert200(putResponse, 1);
+        assertOKResponse(putResponse, 1);
         putResponse.body.data[0].attributes.should.have.property('name').and.be.equal(vocabName);
         putResponse.body.data[0].attributes.should.have.property('tags').and.be.deep.equal(['table']);
 
@@ -184,7 +184,7 @@ describe('Vocabulary-dataset relationships test suite', () => {
             .get(`/api/v1/dataset/${mockDatasetId}/vocabulary`)
             .send({ loggedUser: USERS.ADMIN });
 
-        assert200(getResponse2, 1);
+        assertOKResponse(getResponse2, 1);
         getResponse2.body.data[0].attributes.should.have.property('name').and.be.equal(vocabName);
         getResponse2.body.data[0].attributes.should.have.property('tags').and.be.deep.equal(['table']);
 
@@ -195,7 +195,7 @@ describe('Vocabulary-dataset relationships test suite', () => {
             .patch(`/api/v1/dataset/${mockDatasetId}/vocabulary/${vocabName}`)
             .send({ application: 'rw', tags: ['vector'], loggedUser: USERS.ADMIN });
 
-        assert200(patchResponse, 1);
+        assertOKResponse(patchResponse, 1);
         patchResponse.body.data[0].attributes.should.have.property('name').and.be.equal(vocabName);
         patchResponse.body.data[0].attributes.should.have.property('tags').and.be.deep.equal(['vector']);
 
@@ -205,7 +205,7 @@ describe('Vocabulary-dataset relationships test suite', () => {
         const deleteResponse = await requester
             .delete(`/api/v1/dataset/${mockDatasetId}/vocabulary/${vocabName}?loggedUser=${JSON.stringify(USERS.ADMIN)}`)
             .send();
-        assert200(deleteResponse);
+        assertOKResponse(deleteResponse);
     });
 
     afterEach(async () => {

--- a/app/test/e2e/vocabulary-dataset.spec.js
+++ b/app/test/e2e/vocabulary-dataset.spec.js
@@ -8,9 +8,9 @@ const {
     assert200,
     assert401,
     mockDataset,
-    mockPostGraphAssocition,
-    mockPutGraphAssocition,
-    mockDeleteGraphAssocition,
+    mockPostGraphAssociation,
+    mockPutGraphAssociation,
+    mockDeleteGraphAssociation,
 } = require('./utils');
 const { getTestServer } = require('./test-server');
 
@@ -108,7 +108,7 @@ describe('Vocabulary-dataset relationships test suite', () => {
         const mockDatasetId = mockDataset().id;
 
         // Prepare vocabulary test data
-        const vocabName = 'sciencev2';
+        const vocabName = 'science_v2';
         const vocabData = { application: 'rw', tags: ['biology', 'chemistry'] };
 
         // Perform POST request for creating the vocabulary-dataset relationship
@@ -134,7 +134,7 @@ describe('Vocabulary-dataset relationships test suite', () => {
         const mockDatasetId = mockDataset().id;
 
         // Prepare vocabulary test data
-        const vocabName = 'sciencev3';
+        const vocabName = 'science_v3';
         const vocabData = { application: 'rw', tags: ['biology', 'chemistry'] };
 
         // Perform POST request for creating the vocabulary-dataset relationship
@@ -150,7 +150,7 @@ describe('Vocabulary-dataset relationships test suite', () => {
             .send({ loggedUser: USERS.ADMIN });
 
         assert200(response);
-        response.body.data[0].attributes.should.have.property('name').and.equal('sciencev3');
+        response.body.data[0].attributes.should.have.property('name').and.equal('science_v3');
         response.body.data[0].attributes.should.have.property('application').and.equal('rw');
         response.body.data[0].attributes.should.have.property('tags').and.deep.equal(['biology', 'chemistry']);
     });
@@ -170,7 +170,7 @@ describe('Vocabulary-dataset relationships test suite', () => {
         // Use PUT to add a new vocabulary to the mock dataset
         const putData = {};
         putData[vocabName] = vocabData;
-        mockPostGraphAssocition(mockDatasetId);
+        mockPostGraphAssociation(mockDatasetId);
         const putResponse = await requester
             .put(`/api/v1/dataset/${mockDatasetId}/vocabulary`)
             .send({ ...putData, loggedUser: USERS.ADMIN });
@@ -190,7 +190,7 @@ describe('Vocabulary-dataset relationships test suite', () => {
 
         // Use PATCH to update the inserted vocabulary
         mockDataset(mockDatasetId);
-        mockPutGraphAssocition(mockDatasetId);
+        mockPutGraphAssociation(mockDatasetId);
         const patchResponse = await requester
             .patch(`/api/v1/dataset/${mockDatasetId}/vocabulary/${vocabName}`)
             .send({ application: 'rw', tags: ['vector'], loggedUser: USERS.ADMIN });
@@ -201,7 +201,7 @@ describe('Vocabulary-dataset relationships test suite', () => {
 
         // Use DELETE to remove the created vocabulary
         mockDataset(mockDatasetId);
-        mockDeleteGraphAssocition(mockDatasetId);
+        mockDeleteGraphAssociation(mockDatasetId);
         const deleteResponse = await requester
             .delete(`/api/v1/dataset/${mockDatasetId}/vocabulary/${vocabName}?loggedUser=${JSON.stringify(USERS.ADMIN)}`)
             .send();

--- a/app/test/e2e/vocabulary-dataset.spec.js
+++ b/app/test/e2e/vocabulary-dataset.spec.js
@@ -5,6 +5,8 @@ const Vocabulary = require('models/vocabulary.model');
 
 const { USERS } = require('./test.constants');
 const {
+    assert200,
+    assert401,
     mockDataset,
     mockPostGraphAssocition,
     mockPutGraphAssocition,
@@ -18,20 +20,6 @@ let requester;
 
 nock.disableNetConnect();
 nock.enableNetConnect(process.env.HOST_IP);
-
-const assert401 = (response) => {
-    response.status.should.equal(401);
-    response.body.should.have.property('errors').and.be.an('array');
-    response.body.errors[0].should.have.property('detail').and.equal('Unauthorized');
-};
-
-const assert200 = (response, length = undefined) => {
-    response.status.should.equal(200);
-    response.body.should.have.property('data').and.be.an('array');
-    if (length) {
-        response.body.should.have.property('data').and.be.an('array').and.have.lengthOf(length);
-    }
-};
 
 describe('Vocabulary-dataset relationships test suite', () => {
     beforeEach(async () => {

--- a/app/test/e2e/vocabulary-find.spec.js
+++ b/app/test/e2e/vocabulary-find.spec.js
@@ -3,7 +3,7 @@ const chai = require('chai');
 const Resource = require('models/resource.model');
 const Vocabulary = require('models/vocabulary.model');
 
-const { assert200 } = require('./utils');
+const { assertOKResponse } = require('./utils');
 
 const { getTestServer } = require('./test-server');
 
@@ -27,19 +27,19 @@ describe('Vocabulary find test suite', () => {
     });
 
     it('Finding dataset vocabulary without auth returns 200 OK and a data array', async () => {
-        assert200(await requester.get(`/api/v1/dataset/vocabulary/find`).send());
+        assertOKResponse(await requester.get(`/api/v1/dataset/vocabulary/find`).send());
     });
 
     it('Finding widget vocabulary without auth returns 200 OK and a data array', async () => {
-        assert200(await requester.get(`/api/v1/dataset/123/widget/vocabulary/find`).send());
+        assertOKResponse(await requester.get(`/api/v1/dataset/123/widget/vocabulary/find`).send());
     });
 
     it('Finding layer vocabulary without auth returns 200 OK and a data array', async () => {
-        assert200(await requester.get(`/api/v1/dataset/123/layer/vocabulary/find`).send());
+        assertOKResponse(await requester.get(`/api/v1/dataset/123/layer/vocabulary/find`).send());
     });
 
     it('Finding all vocabulary without auth returns 200 OK and a data array', async () => {
-        assert200(await requester.get(`/api/v1/vocabulary`).send());
+        assertOKResponse(await requester.get(`/api/v1/vocabulary`).send());
     });
 
     afterEach(async () => {

--- a/app/test/e2e/vocabulary-find.spec.js
+++ b/app/test/e2e/vocabulary-find.spec.js
@@ -26,19 +26,19 @@ describe('Vocabulary find test suite', () => {
         await Vocabulary.deleteMany().exec();
     });
 
-    it('Findind dataset vocabulary without auth returns 200 OK and a data array', async () => {
+    it('Finding dataset vocabulary without auth returns 200 OK and a data array', async () => {
         assert200(await requester.get(`/api/v1/dataset/vocabulary/find`).send());
     });
 
-    it('Findind widget vocabulary without auth returns 200 OK and a data array', async () => {
+    it('Finding widget vocabulary without auth returns 200 OK and a data array', async () => {
         assert200(await requester.get(`/api/v1/dataset/123/widget/vocabulary/find`).send());
     });
 
-    it('Findind layer vocabulary without auth returns 200 OK and a data array', async () => {
+    it('Finding layer vocabulary without auth returns 200 OK and a data array', async () => {
         assert200(await requester.get(`/api/v1/dataset/123/layer/vocabulary/find`).send());
     });
 
-    it('Findind all vocabulary without auth returns 200 OK and a data array', async () => {
+    it('Finding all vocabulary without auth returns 200 OK and a data array', async () => {
         assert200(await requester.get(`/api/v1/vocabulary`).send());
     });
 

--- a/app/test/e2e/vocabulary-find.spec.js
+++ b/app/test/e2e/vocabulary-find.spec.js
@@ -3,6 +3,8 @@ const chai = require('chai');
 const Resource = require('models/resource.model');
 const Vocabulary = require('models/vocabulary.model');
 
+const { assert200 } = require('./utils');
+
 const { getTestServer } = require('./test-server');
 
 chai.should();
@@ -25,27 +27,19 @@ describe('Vocabulary find test suite', () => {
     });
 
     it('Findind dataset vocabulary without auth returns 200 OK and a data array', async () => {
-        const response = await requester.get(`/api/v1/dataset/vocabulary/find`).send();
-        response.status.should.equal(200);
-        response.body.should.have.property('data').and.be.an('array');
+        assert200(await requester.get(`/api/v1/dataset/vocabulary/find`).send());
     });
 
     it('Findind widget vocabulary without auth returns 200 OK and a data array', async () => {
-        const response = await requester.get(`/api/v1/dataset/123/widget/vocabulary/find`).send();
-        response.status.should.equal(200);
-        response.body.should.have.property('data').and.be.an('array');
+        assert200(await requester.get(`/api/v1/dataset/123/widget/vocabulary/find`).send());
     });
 
     it('Findind layer vocabulary without auth returns 200 OK and a data array', async () => {
-        const response = await requester.get(`/api/v1/dataset/123/layer/vocabulary/find`).send();
-        response.status.should.equal(200);
-        response.body.should.have.property('data').and.be.an('array');
+        assert200(await requester.get(`/api/v1/dataset/123/layer/vocabulary/find`).send());
     });
 
     it('Findind all vocabulary without auth returns 200 OK and a data array', async () => {
-        const response = await requester.get(`/api/v1/vocabulary`).send();
-        response.status.should.equal(200);
-        response.body.should.have.property('data').and.be.an('array');
+        assert200(await requester.get(`/api/v1/vocabulary`).send());
     });
 
     afterEach(async () => {


### PR DESCRIPTION
**Related to the following PT task:**
- https://www.pivotaltracker.com/story/show/169420749

Long story short, when PUTting, PATCHing or DELETEing vocabularies associated with datasets, an interaction happens with the Graph MS. If this interaction fails by some reason (for instance, inconsistencies in the data between the Vocabulary MS and Graph MS), the changes are applied only to the Vocabulary MS database, though the overall request returns an error.

I tested in the production environment, where the data is usually more consistent than in staging environment, and I was not able to reproduce the problem. I also added some tests for ensuring this problem will not happen in the future and have improved the log and error messages, so that in the future we can debug problems like this easier.

This PR ensures that **IF the communication with Graph MS goes well, no problem will occur in the Vocabulary MS.** If a problem occurs in the comms with Graph MS, then it will be easier to understand where the error happen.