### PR TITLE
Bugfix for PATCHing dataset tags when the dataset is not present in the vocabulary resources

### DIFF
--- a/app/src/services/relationship.service.js
+++ b/app/src/services/relationship.service.js
@@ -154,7 +154,19 @@ class RelationshipService {
                 }
             }
             logger.debug(`Tags to vocabulary`);
-            vocabulary.resources[position].tags = body.tags;
+
+            // If the resource has not been found in the vocabulary resources, push it!
+            if (!position) {
+                vocabulary.resources.push({
+                    id: resource.id,
+                    dataset,
+                    type: resource.type,
+                    tags: body.tags,
+                });
+            } else {
+                vocabulary.resources[position].tags = body.tags;
+            }
+
             vocabulary.save();
         } catch (err) {
             throw err;

--- a/app/src/services/relationship.service.js
+++ b/app/src/services/relationship.service.js
@@ -156,7 +156,7 @@ class RelationshipService {
             logger.debug(`Tags to vocabulary`);
 
             // If the resource has not been found in the vocabulary resources, push it!
-            if (!position) {
+            if (position === undefined) {
                 vocabulary.resources.push({
                     id: resource.id,
                     dataset,


### PR DESCRIPTION
**Related to the following PT tasks:**

- https://www.pivotaltracker.com/story/show/169475083
- https://www.pivotaltracker.com/story/show/169230343

It was detected that if a given dataset (X) is associated with a given vocabulary (Y), but the dataset X is not present in the resources attribute of the vocabulary, then 404 is returned with an error `cannot set property tags of undefined`, as reported in the PT task.

This PR adds the correction (pushing the dataset X to the resources of vocab Y when not present), as well as a test that confirms the buggy behaviour and that it currently is fixed.

Both PT tasks report the same problem, and this PR provides the fix for both tasks.