### PR TITLE
Rebuild Graph MS data when a 404 Resource Not Found is returned

### DIFF
--- a/app/src/routes/api/v1/vocabulary.router.js
+++ b/app/src/routes/api/v1/vocabulary.router.js
@@ -206,7 +206,7 @@ class VocabularyRouter {
             }
         });
         vocabularies.forEach((vocabulary) => {
-            logger.info(`Creating realtionships between vocabulary: ${vocabulary.name} and resource: ${resource.type} - ${resource.id}`);
+            logger.info(`Creating relationships between vocabulary: ${vocabulary.name} and resource: ${resource.type} - ${resource.id}`);
         });
         try {
             const user = ctx.request.body.loggedUser;
@@ -252,7 +252,7 @@ class VocabularyRouter {
             }
         });
         vocabularies.forEach((vocabulary) => {
-            logger.info(`Creating realtionships between vocabulary: ${vocabulary.name} and resource: ${resource.type} - ${resource.id}`);
+            logger.info(`Creating relationships between vocabulary: ${vocabulary.name} and resource: ${resource.type} - ${resource.id}`);
         });
         try {
             const user = ctx.request.body.loggedUser;

--- a/app/src/services/graph.service.js
+++ b/app/src/services/graph.service.js
@@ -29,15 +29,17 @@ const createResource = async (resource) => {
 
 const postGraphAssociation = async (resource, tags, application) => {
     try {
-        return ctRegisterMicroservice.requestToMicroservice({
+        const res = await ctRegisterMicroservice.requestToMicroservice({
             uri: `/graph/${resource.type}/${resource.id}/associate`,
             method: 'POST',
             json: true,
             body: { tags, application }
         });
+
+        return res;
     } catch (err) {
         // Check if error matches resource not found, and if so try to create the resource first hand
-        if (err.message.match(/Resource.*not found/g)) {
+        if (err.message.match(/Resource.*not found/g) !== null) {
             await createResource(resource);
             return ctRegisterMicroservice.requestToMicroservice({
                 uri: `/graph/${resource.type}/${resource.id}/associate`,
@@ -53,15 +55,17 @@ const postGraphAssociation = async (resource, tags, application) => {
 
 const putGraphAssociation = async (resource, tags, application) => {
     try {
-        return ctRegisterMicroservice.requestToMicroservice({
+        const res = await ctRegisterMicroservice.requestToMicroservice({
             uri: `/graph/${resource.type}/${resource.id}/associate`,
             method: 'PUT',
             json: true,
             body: { tags, application }
         });
+
+        return res;
     } catch (err) {
         // Check if error matches resource not found, and if so try to create the resource first hand
-        if (err.message.match(/Resource.*not found/g)) {
+        if (err.message.match(/Resource.*not found/g) !== null) {
             await createResource(resource);
             return ctRegisterMicroservice.requestToMicroservice({
                 uri: `/graph/${resource.type}/${resource.id}/associate`,
@@ -85,20 +89,15 @@ const getDeleteURL = (resource, application) => {
 
 const deleteGraphAssociation = async (resource, application) => {
     try {
-        return ctRegisterMicroservice.requestToMicroservice({
+        await ctRegisterMicroservice.requestToMicroservice({
             uri: getDeleteURL(resource, application),
             method: 'DELETE',
             json: true
         });
     } catch (err) {
-        // Check if error matches resource not found, and if so try to create the resource first hand
-        if (err.message.match(/Resource.*not found/g)) {
-            await createResource(resource);
-            return ctRegisterMicroservice.requestToMicroservice({
-                uri: getDeleteURL(resource, application),
-                method: 'DELETE',
-                json: true
-            });
+        // Check if error matches resource not found, and in that case fail silently
+        if (err.message.match(/Resource.*not found/g) !== null) {
+            return;
         }
 
         throw err;

--- a/app/test/e2e/utils.js
+++ b/app/test/e2e/utils.js
@@ -225,19 +225,36 @@ const mockLayer = (id = undefined, extraData = {}) => {
 const mockPostGraphAssociation = (datasetId, mockSuccess = true) => {
     nock(process.env.CT_URL)
         .post(`/v1/graph/dataset/${datasetId}/associate`)
-        .reply(mockSuccess ? 200 : 404, { data: {} });
+        .reply(mockSuccess ? 200 : 404, { data: mockSuccess ? {} : { message: 'Resource XXXX not found.' } });
+
+    if (!mockSuccess) {
+        nock(process.env.CT_URL)
+            .post(`/v1/graph/dataset/${datasetId}`)
+            .reply(200, { data: {} });
+
+        nock(process.env.CT_URL)
+            .post(`/v1/graph/dataset/${datasetId}/associate`).reply(200, { data: {} });
+    }
 };
 
 const mockPutGraphAssociation = (datasetId, mockSuccess = true) => {
     nock(process.env.CT_URL)
         .put(`/v1/graph/dataset/${datasetId}/associate`)
-        .reply(mockSuccess ? 200 : 404, { data: {} });
+        .reply(mockSuccess ? 200 : 404, { data: mockSuccess ? {} : { message: 'Resource XXXX not found.' } });
+
+    if (!mockSuccess) {
+        nock(process.env.CT_URL)
+            .post(`/v1/graph/dataset/${datasetId}`).reply(200, { data: {} });
+
+        nock(process.env.CT_URL)
+            .put(`/v1/graph/dataset/${datasetId}/associate`).reply(200, { data: {} });
+    }
 };
 
 const mockDeleteGraphAssociation = (datasetId, application = 'rw', mockSuccess = true) => {
     nock(process.env.CT_URL)
         .delete(`/v1/graph/dataset/${datasetId}/associate?application=${application}`)
-        .reply(mockSuccess ? 200 : 404, { data: {} });
+        .reply(mockSuccess ? 200 : 404, { data: mockSuccess ? {} : { message: 'Resource XXXX not found.' } });
 };
 
 const assertUnauthorizedResponse = (response) => {

--- a/app/test/e2e/vocabulary-dataset.spec.js
+++ b/app/test/e2e/vocabulary-dataset.spec.js
@@ -4,14 +4,7 @@ const Resource = require('models/resource.model');
 const Vocabulary = require('models/vocabulary.model');
 
 const { USERS } = require('./test.constants');
-const {
-    assertOKResponse,
-    assertUnauthorizedResponse,
-    mockDataset,
-    mockPostGraphAssociation,
-    mockPutGraphAssociation,
-    mockDeleteGraphAssociation,
-} = require('./utils');
+const { assertOKResponse, assertUnauthorizedResponse, mockDataset } = require('./utils');
 const { getTestServer } = require('./test-server');
 
 chai.should();
@@ -20,35 +13,6 @@ let requester;
 
 nock.disableNetConnect();
 nock.enableNetConnect(process.env.HOST_IP);
-
-const assertCountOfVocabDatasetRelationships = async (datasetId, length) => {
-    assertOKResponse(await requester
-        .get(`/api/v1/dataset/${datasetId}/vocabulary`)
-        .send({ loggedUser: USERS.ADMIN }), length);
-};
-
-const putVocabDatasetRelationship = async (datasetId, vocabName, vocabData = {}) => {
-    const putData = {};
-    putData[vocabName] = vocabData;
-    mockPostGraphAssociation(datasetId);
-    return requester.put(`/api/v1/dataset/${datasetId}/vocabulary`)
-        .send({ ...putData, loggedUser: USERS.ADMIN });
-};
-
-const patchVocabDatasetRelationship = async (datasetId, vocabName, vocabData = {}) => {
-    mockDataset(datasetId);
-    mockPutGraphAssociation(datasetId);
-    return requester.patch(`/api/v1/dataset/${datasetId}/vocabulary/${vocabName}`)
-        .send({ ...vocabData, loggedUser: USERS.ADMIN });
-};
-
-const deleteVocabDatasetRelationship = async (datasetId, vocabName) => {
-    mockDataset(datasetId);
-    mockDeleteGraphAssociation(datasetId);
-    return requester
-        .delete(`/api/v1/dataset/${datasetId}/vocabulary/${vocabName}?loggedUser=${JSON.stringify(USERS.ADMIN)}`)
-        .send();
-};
 
 describe('Vocabulary-dataset relationships test suite', () => {
     beforeEach(async () => {
@@ -182,94 +146,6 @@ describe('Vocabulary-dataset relationships test suite', () => {
         response.body.data[0].attributes.should.have.property('name').and.equal('science_v3');
         response.body.data[0].attributes.should.have.property('application').and.equal('rw');
         response.body.data[0].attributes.should.have.property('tags').and.deep.equal(['biology', 'chemistry']);
-    });
-
-    it('PUTting vocab-dataset relationships with auth returns 200 OK with created data', async () => {
-        // Assert no relationships exist for the mock dataset created
-        const mockDatasetId = mockDataset().id;
-        await assertCountOfVocabDatasetRelationships(mockDatasetId, 0);
-
-        // PUT one vocabulary relationship
-        const putResponse = await putVocabDatasetRelationship(
-            mockDatasetId,
-            'knowledge_graph',
-            { application: 'rw', tags: ['table'] },
-        );
-        assertOKResponse(putResponse);
-        putResponse.body.data[0].attributes.should.have.property('name').and.be.equal('knowledge_graph');
-        putResponse.body.data[0].attributes.should.have.property('tags').and.be.deep.equal(['table']);
-
-        // Assert that exists one relationship for the mock dataset created
-        await assertCountOfVocabDatasetRelationships(mockDatasetId, 1);
-    });
-
-    it('PATCHing vocab-dataset relationships with auth returns 200 OK with updated data', async () => {
-        // PUT one vocabulary relationship
-        const mockDatasetId = mockDataset().id;
-        assertOKResponse(await putVocabDatasetRelationship(
-            mockDatasetId,
-            'knowledge_graph',
-            { application: 'rw', tags: ['table'] },
-        ));
-
-        // Assert that exists one relationship for the mock dataset created
-        await assertCountOfVocabDatasetRelationships(mockDatasetId, 1);
-
-        // PATCH the previously created relationship
-        const patchResponse = await patchVocabDatasetRelationship(
-            mockDatasetId,
-            'knowledge_graph',
-            { application: 'rw', tags: ['vector'] },
-        );
-        assertOKResponse(patchResponse);
-        patchResponse.body.data[0].attributes.should.have.property('name').and.be.equal('knowledge_graph');
-        patchResponse.body.data[0].attributes.should.have.property('tags').and.be.deep.equal(['vector']);
-
-        // Assert that still exists one relationship for the mock dataset updated
-        await assertCountOfVocabDatasetRelationships(mockDatasetId, 1);
-    });
-
-    it('DELETing vocab-dataset relationships with auth returns 200 OK with no data', async () => {
-        // PUT one vocabulary relationship
-        const mockDatasetId = mockDataset().id;
-        assertOKResponse(await putVocabDatasetRelationship(
-            mockDatasetId,
-            'knowledge_graph',
-            { application: 'rw', tags: ['table'] },
-        ));
-
-        // Assert that exists one relationship for the mock dataset created
-        await assertCountOfVocabDatasetRelationships(mockDatasetId, 1);
-
-        // DELETE the previously created relationship
-        assertOKResponse(await deleteVocabDatasetRelationship(mockDatasetId, 'knowledge_graph'));
-
-        // Assert that no relationship exists for the mock dataset created
-        await assertCountOfVocabDatasetRelationships(mockDatasetId, 0);
-    });
-
-    it('PATCHing vocab-dataset relationships when the resource is not present in the vocabulary resources list returns 200 OK with updated data', async () => {
-        const mockDatasetId = mockDataset().id;
-        assertOKResponse(await putVocabDatasetRelationship(
-            mockDatasetId,
-            'knowledge_graph',
-            { application: 'rw', tags: ['table'] },
-        ));
-
-        // Manually eliminate the resource from the vocabulary list
-        const vocab = await Vocabulary.findOne({ id: 'knowledge_graph' });
-        vocab.resources = [];
-        await vocab.save();
-
-        const patchResponse = await patchVocabDatasetRelationship(
-            mockDatasetId,
-            'knowledge_graph',
-            { application: 'rw', tags: ['vector'] },
-        );
-
-        assertOKResponse(patchResponse);
-        patchResponse.body.data[0].attributes.should.have.property('name').and.be.equal('knowledge_graph');
-        patchResponse.body.data[0].attributes.should.have.property('tags').and.be.deep.equal(['vector']);
     });
 
     afterEach(async () => {

--- a/app/test/e2e/vocabulary-graph.spec.js
+++ b/app/test/e2e/vocabulary-graph.spec.js
@@ -1,0 +1,160 @@
+const nock = require('nock');
+const chai = require('chai');
+const Resource = require('models/resource.model');
+const Vocabulary = require('models/vocabulary.model');
+
+const { USERS } = require('./test.constants');
+const {
+    assertOKResponse,
+    mockDataset,
+    mockPostGraphAssociation,
+    mockPutGraphAssociation,
+    mockDeleteGraphAssociation,
+} = require('./utils');
+const { getTestServer } = require('./test-server');
+
+chai.should();
+
+let requester;
+
+nock.disableNetConnect();
+nock.enableNetConnect(process.env.HOST_IP);
+
+const assertCountOfVocabDatasetRelationships = async (datasetId, length) => {
+    assertOKResponse(await requester
+        .get(`/api/v1/dataset/${datasetId}/vocabulary`)
+        .send({ loggedUser: USERS.ADMIN }), length);
+};
+
+const putVocabDatasetRelationship = async (datasetId, vocabName, vocabData = {}) => {
+    const putData = {};
+    putData[vocabName] = vocabData;
+    mockPostGraphAssociation(datasetId);
+    return requester.put(`/api/v1/dataset/${datasetId}/vocabulary`)
+        .send({ ...putData, loggedUser: USERS.ADMIN });
+};
+
+const patchVocabDatasetRelationship = async (datasetId, vocabName, vocabData = {}) => {
+    mockDataset(datasetId);
+    mockPutGraphAssociation(datasetId);
+    return requester.patch(`/api/v1/dataset/${datasetId}/vocabulary/${vocabName}`)
+        .send({ ...vocabData, loggedUser: USERS.ADMIN });
+};
+
+const deleteVocabDatasetRelationship = async (datasetId, vocabName) => {
+    mockDataset(datasetId);
+    mockDeleteGraphAssociation(datasetId);
+    return requester
+        .delete(`/api/v1/dataset/${datasetId}/vocabulary/${vocabName}?loggedUser=${JSON.stringify(USERS.ADMIN)}`)
+        .send();
+};
+
+describe('Vocabulary interaction with Graph MS test suite', () => {
+    beforeEach(async () => {
+        if (process.env.NODE_ENV !== 'test') {
+            throw Error(`Running the test suite with NODE_ENV ${process.env.NODE_ENV} may result in permanent data loss. Please use NODE_ENV=test.`);
+        }
+
+        requester = await getTestServer();
+
+        await Resource.deleteMany().exec();
+        await Vocabulary.deleteMany().exec();
+    });
+
+    it('PUTting vocab-dataset relationships with auth returns 200 OK with created data', async () => {
+        // Assert no relationships exist for the mock dataset created
+        const mockDatasetId = mockDataset().id;
+        await assertCountOfVocabDatasetRelationships(mockDatasetId, 0);
+
+        // PUT one vocabulary relationship
+        const putResponse = await putVocabDatasetRelationship(
+            mockDatasetId,
+            'knowledge_graph',
+            { application: 'rw', tags: ['table'] },
+        );
+        assertOKResponse(putResponse);
+        putResponse.body.data[0].attributes.should.have.property('name').and.be.equal('knowledge_graph');
+        putResponse.body.data[0].attributes.should.have.property('tags').and.be.deep.equal(['table']);
+
+        // Assert that exists one relationship for the mock dataset created
+        await assertCountOfVocabDatasetRelationships(mockDatasetId, 1);
+    });
+
+    it('PATCHing vocab-dataset relationships with auth returns 200 OK with updated data', async () => {
+        // PUT one vocabulary relationship
+        const mockDatasetId = mockDataset().id;
+        assertOKResponse(await putVocabDatasetRelationship(
+            mockDatasetId,
+            'knowledge_graph',
+            { application: 'rw', tags: ['table'] },
+        ));
+
+        // Assert that exists one relationship for the mock dataset created
+        await assertCountOfVocabDatasetRelationships(mockDatasetId, 1);
+
+        // PATCH the previously created relationship
+        const patchResponse = await patchVocabDatasetRelationship(
+            mockDatasetId,
+            'knowledge_graph',
+            { application: 'rw', tags: ['vector'] },
+        );
+        assertOKResponse(patchResponse);
+        patchResponse.body.data[0].attributes.should.have.property('name').and.be.equal('knowledge_graph');
+        patchResponse.body.data[0].attributes.should.have.property('tags').and.be.deep.equal(['vector']);
+
+        // Assert that still exists one relationship for the mock dataset updated
+        await assertCountOfVocabDatasetRelationships(mockDatasetId, 1);
+    });
+
+    it('DELETing vocab-dataset relationships with auth returns 200 OK with no data', async () => {
+        // PUT one vocabulary relationship
+        const mockDatasetId = mockDataset().id;
+        assertOKResponse(await putVocabDatasetRelationship(
+            mockDatasetId,
+            'knowledge_graph',
+            { application: 'rw', tags: ['table'] },
+        ));
+
+        // Assert that exists one relationship for the mock dataset created
+        await assertCountOfVocabDatasetRelationships(mockDatasetId, 1);
+
+        // DELETE the previously created relationship
+        assertOKResponse(await deleteVocabDatasetRelationship(mockDatasetId, 'knowledge_graph'));
+
+        // Assert that no relationship exists for the mock dataset created
+        await assertCountOfVocabDatasetRelationships(mockDatasetId, 0);
+    });
+
+    it('PATCHing vocab-dataset relationships when the resource is not present in the vocabulary resources list returns 200 OK with updated data', async () => {
+        const mockDatasetId = mockDataset().id;
+        assertOKResponse(await putVocabDatasetRelationship(
+            mockDatasetId,
+            'knowledge_graph',
+            { application: 'rw', tags: ['table'] },
+        ));
+
+        // Manually eliminate the resource from the vocabulary list
+        const vocab = await Vocabulary.findOne({ id: 'knowledge_graph' });
+        vocab.resources = [];
+        await vocab.save();
+
+        const patchResponse = await patchVocabDatasetRelationship(
+            mockDatasetId,
+            'knowledge_graph',
+            { application: 'rw', tags: ['vector'] },
+        );
+
+        assertOKResponse(patchResponse);
+        patchResponse.body.data[0].attributes.should.have.property('name').and.be.equal('knowledge_graph');
+        patchResponse.body.data[0].attributes.should.have.property('tags').and.be.deep.equal(['vector']);
+    });
+
+    afterEach(async () => {
+        if (!nock.isDone()) {
+            throw new Error(`Not all nock interceptors were used: ${nock.pendingMocks()}`);
+        }
+
+        await Resource.deleteMany().exec();
+        await Vocabulary.deleteMany().exec();
+    });
+});

--- a/app/test/e2e/vocabulary-graph.spec.js
+++ b/app/test/e2e/vocabulary-graph.spec.js
@@ -26,24 +26,32 @@ const assertCountOfVocabDatasetRelationships = async (datasetId, length) => {
         .send({ loggedUser: USERS.ADMIN }), length);
 };
 
-const putVocabDatasetRelationship = async (datasetId, vocabName, vocabData = {}) => {
+const postVocabDatasetRelationship = async (datasetId, vocabName, vocabData = {}) => {
+    const postData = {};
+    postData[vocabName] = vocabData;
+    mockPostGraphAssociation(datasetId);
+    return requester.put(`/api/v1/dataset/${datasetId}/vocabulary`)
+        .send({ ...postData, loggedUser: USERS.ADMIN });
+};
+
+const putVocabDatasetRelationship = async (datasetId, vocabName, vocabData = {}, graphSuccess = true) => {
     const putData = {};
     putData[vocabName] = vocabData;
-    mockPostGraphAssociation(datasetId);
+    mockPostGraphAssociation(datasetId, graphSuccess);
     return requester.put(`/api/v1/dataset/${datasetId}/vocabulary`)
         .send({ ...putData, loggedUser: USERS.ADMIN });
 };
 
-const patchVocabDatasetRelationship = async (datasetId, vocabName, vocabData = {}) => {
+const patchVocabDatasetRelationship = async (datasetId, vocabName, vocabData = {}, graphSuccess = true) => {
     mockDataset(datasetId);
-    mockPutGraphAssociation(datasetId);
+    mockPutGraphAssociation(datasetId, graphSuccess);
     return requester.patch(`/api/v1/dataset/${datasetId}/vocabulary/${vocabName}`)
         .send({ ...vocabData, loggedUser: USERS.ADMIN });
 };
 
-const deleteVocabDatasetRelationship = async (datasetId, vocabName) => {
+const deleteVocabDatasetRelationship = async (datasetId, vocabName, graphSuccess = true) => {
     mockDataset(datasetId);
-    mockDeleteGraphAssociation(datasetId);
+    mockDeleteGraphAssociation(datasetId, 'rw', graphSuccess);
     return requester
         .delete(`/api/v1/dataset/${datasetId}/vocabulary/${vocabName}?loggedUser=${JSON.stringify(USERS.ADMIN)}`)
         .send();
@@ -59,6 +67,25 @@ describe('Vocabulary interaction with Graph MS test suite', () => {
 
         await Resource.deleteMany().exec();
         await Vocabulary.deleteMany().exec();
+    });
+
+    it('POSTing vocab-dataset relationships with auth returns 200 OK with created data', async () => {
+        // Assert no relationships exist for the mock dataset created
+        const mockDatasetId = mockDataset().id;
+        await assertCountOfVocabDatasetRelationships(mockDatasetId, 0);
+
+        // POST one vocabulary relationship
+        const postResponse = await postVocabDatasetRelationship(
+            mockDatasetId,
+            'knowledge_graph',
+            { application: 'rw', tags: ['table'] },
+        );
+        assertOKResponse(postResponse);
+        postResponse.body.data[0].attributes.should.have.property('name').and.be.equal('knowledge_graph');
+        postResponse.body.data[0].attributes.should.have.property('tags').and.be.deep.equal(['table']);
+
+        // Assert that exists one relationship for the mock dataset created
+        await assertCountOfVocabDatasetRelationships(mockDatasetId, 1);
     });
 
     it('PUTting vocab-dataset relationships with auth returns 200 OK with created data', async () => {
@@ -147,6 +174,72 @@ describe('Vocabulary interaction with Graph MS test suite', () => {
         assertOKResponse(patchResponse);
         patchResponse.body.data[0].attributes.should.have.property('name').and.be.equal('knowledge_graph');
         patchResponse.body.data[0].attributes.should.have.property('tags').and.be.deep.equal(['vector']);
+    });
+
+    it('PUTting vocab-graph relationships when Graph request fails should return 200 OK with created data', async () => {
+        // Assert no relationships exist for the mock dataset created
+        const mockDatasetId = mockDataset().id;
+        await assertCountOfVocabDatasetRelationships(mockDatasetId, 0);
+
+        // PUT one vocabulary relationship
+        const putResponse = await putVocabDatasetRelationship(
+            mockDatasetId,
+            'knowledge_graph',
+            { application: 'rw', tags: ['table'] },
+            false,
+        );
+        assertOKResponse(putResponse);
+        putResponse.body.data[0].attributes.should.have.property('name').and.be.equal('knowledge_graph');
+        putResponse.body.data[0].attributes.should.have.property('tags').and.be.deep.equal(['table']);
+
+        // Assert that exists one relationship for the mock dataset created
+        await assertCountOfVocabDatasetRelationships(mockDatasetId, 1);
+    });
+
+    it('PATCHing vocab-graph relationships when Graph request fails should return 200 OK with updated data', async () => {
+        // PUT one vocabulary relationship
+        const mockDatasetId = mockDataset().id;
+        assertOKResponse(await putVocabDatasetRelationship(
+            mockDatasetId,
+            'knowledge_graph',
+            { application: 'rw', tags: ['table'] },
+        ));
+
+        // Assert that exists one relationship for the mock dataset created
+        await assertCountOfVocabDatasetRelationships(mockDatasetId, 1);
+
+        // PATCH the previously created relationship -- with error!
+        const patchResponse = await patchVocabDatasetRelationship(
+            mockDatasetId,
+            'knowledge_graph',
+            { application: 'rw', tags: ['vector'] },
+            false,
+        );
+        assertOKResponse(patchResponse);
+        patchResponse.body.data[0].attributes.should.have.property('name').and.be.equal('knowledge_graph');
+        patchResponse.body.data[0].attributes.should.have.property('tags').and.be.deep.equal(['vector']);
+
+        // Assert that still exists one relationship for the mock dataset updated
+        await assertCountOfVocabDatasetRelationships(mockDatasetId, 1);
+    });
+
+    it('DELETing vocab-graph relationships when Graph request fails should return 200 OK with no data', async () => {
+        // PUT one vocabulary relationship
+        const mockDatasetId = mockDataset().id;
+        assertOKResponse(await putVocabDatasetRelationship(
+            mockDatasetId,
+            'knowledge_graph',
+            { application: 'rw', tags: ['table'] },
+        ));
+
+        // Assert that exists one relationship for the mock dataset created
+        await assertCountOfVocabDatasetRelationships(mockDatasetId, 1);
+
+        // DELETE the previously created relationship
+        assertOKResponse(await deleteVocabDatasetRelationship(mockDatasetId, 'knowledge_graph', false));
+
+        // Assert that no relationship exists for the mock dataset created
+        await assertCountOfVocabDatasetRelationships(mockDatasetId, 0);
     });
 
     afterEach(async () => {


### PR DESCRIPTION
This PR relates to the following PT task: https://www.pivotaltracker.com/story/show/169420749 and to the following PR #4

Detects when Graph MS returns consistency errors ("Resource XXXX not found") and tries to re-create the resource in the Graph before trying again the Graph operation intended.

Tests included validate that if there is a 404 response by the Graph MS, the operation intended in the Vocabulary MS still returns 200 OK and is performed correctly.