### PR TITLE
Update local docker setup so it builds and registers with the Control Tower correctly

### DIFF
--- a/dev.env.sample
+++ b/dev.env.sample
@@ -1,2 +1,2 @@
-CT_URL=http://mymychine:9000
-LOCAL_URL=http://mymychine:3000
+CT_URL=http://mymachine:9000
+LOCAL_URL=http://mymachine:4101

--- a/docker-compose-develop.yml
+++ b/docker-compose-develop.yml
@@ -3,15 +3,20 @@ services:
   develop:
     build: .
     ports:
-      - "4100"
+      - "4101:4101"
     container_name: vocabulary-tag-develop
     env_file:
       - dev.env
     environment:
-      CT_REGISTER_MODE: auto
-      CT_TOKEN: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6Im1pY3Jvc2VydmljZSIsImNyZWF0ZWRBdCI6IjIwMTYtMDktMTQifQ.IRCIRm1nfIQTfda_Wb6Pg-341zhV8soAgzw7dd5HxxQ
+      PORT: 4101
+      NODE_ENV: test
+      NODE_PATH: app/src
+      CT_URL: http://mymachine:9000
       API_VERSION: v1
-      LOCAL_URL: http://mymachine:3055
+      CT_REGISTER_MODE: auto
+      MONGO_PORT_27017_TCP_ADDR: mongo
+      LOCAL_URL: http://mymachine:4101
+      CT_TOKEN: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6Im1pY3Jvc2VydmljZSIsImNyZWF0ZWRBdCI6IjIwMTYtMDktMTQifQ.IRCIRm1nfIQTfda_Wb6Pg-341zhV8soAgzw7dd5HxxQ
       FASTLY_ENABLED: "false"
     command: develop
     links:


### PR DESCRIPTION
I have made a series of small changes which ensures that the microservices build and register with the Control Tower locally with Docker.

The changes to this repo are:
- Fix dev.env.sample typos
- Update port so it does not clash with another service
- Add many missing configs