### PR TITLE
All environments collection filter

### DIFF
--- a/app/src/services/collection.service.js
+++ b/app/src/services/collection.service.js
@@ -138,7 +138,8 @@ class CollectionService {
 
         const filters = {
             ownerId: user.id,
-            application
+            application,
+            env: query.env ? query.env : 'production'
         };
 
         Object.keys(query).forEach((param) => {
@@ -170,14 +171,16 @@ class CollectionService {
 
                 }
             } else if (param === 'env') {
-                filters[param] = {
-                    $in: query[param].split(',')
-                };
+                if (query[param] === 'all') {
+                    logger.debug('Applying all environments filter');
+                    delete filters.env;
+                } else {
+                    filters[param] = {
+                        $in: query[param].split(',')
+                    };
+                }
             }
         });
-        if (!filters.env) { // default value
-            filters.env = 'production';
-        }
 
         logger.info(filters);
         return filters;

--- a/app/test/e2e/collection/collection-get-all.spec.js
+++ b/app/test/e2e/collection/collection-get-all.spec.js
@@ -436,6 +436,7 @@ describe('Get collections', () => {
 
             response.status.should.equal(200);
             response.body.should.have.property('data').and.be.an('array').and.length(9);
+            [...new Set(response.body.data.map((elem) => elem.attributes.env))].sort().should.eql(['production', 'custom'].sort());
             response.body.should.have.property('links').and.be.an('object');
             response.body.links.should.have.property('self').and.equal(`http://127.0.0.1:${config.get('service.port')}/v1/collection?env=all&page[number]=1&page[size]=9999999`);
             response.body.links.should.have.property('prev').and.equal(`http://127.0.0.1:${config.get('service.port')}/v1/collection?env=all&page[number]=1&page[size]=9999999`);

--- a/app/test/e2e/collection/collection-get-all.spec.js
+++ b/app/test/e2e/collection/collection-get-all.spec.js
@@ -400,6 +400,50 @@ describe('Get collections', () => {
             response.body.links.should.have.property('last').and.equal(`http://127.0.0.1:${config.get('service.port')}/v1/collection?page[number]=1&page[size]=9999999`);
         });
 
+        it('Getting collections applying env filter "all" returns collections from every env', async () => {
+            mockGetUserFromToken(USERS.USER);
+
+            for (let i = 0; i < 3; i++) {
+                await new Collection(createCollection({
+                    application: 'rw',
+                    ownerId: USERS.USER.id,
+                    env: 'production'
+                })).save();
+            }
+
+            for (let i = 0; i < 3; i++) {
+                await new Collection(createCollection({
+                    application: 'rw',
+                    ownerId: USERS.USER.id,
+                })).save();
+            }
+
+            for (let i = 0; i < 3; i++) {
+                await new Collection(createCollection({
+                    application: 'rw',
+                    ownerId: USERS.USER.id,
+                    env: 'custom'
+                })).save();
+            }
+
+            const response = await requester
+                .get(`/api/v1/collection`)
+                .set('Authorization', `Bearer abcd`)
+                .query({
+                    env: 'all'
+                })
+                .send();
+
+            response.status.should.equal(200);
+            response.body.should.have.property('data').and.be.an('array').and.length(9);
+            response.body.should.have.property('links').and.be.an('object');
+            response.body.links.should.have.property('self').and.equal(`http://127.0.0.1:${config.get('service.port')}/v1/collection?env=all&page[number]=1&page[size]=9999999`);
+            response.body.links.should.have.property('prev').and.equal(`http://127.0.0.1:${config.get('service.port')}/v1/collection?env=all&page[number]=1&page[size]=9999999`);
+            response.body.links.should.have.property('next').and.equal(`http://127.0.0.1:${config.get('service.port')}/v1/collection?env=all&page[number]=1&page[size]=9999999`);
+            response.body.links.should.have.property('first').and.equal(`http://127.0.0.1:${config.get('service.port')}/v1/collection?env=all&page[number]=1&page[size]=9999999`);
+            response.body.links.should.have.property('last').and.equal(`http://127.0.0.1:${config.get('service.port')}/v1/collection?env=all&page[number]=1&page[size]=9999999`);
+        });
+
         it('Getting collections with the env filter set to a custom value should returns all collections with that env', async () => {
             mockGetUserFromToken(USERS.USER);
 


### PR DESCRIPTION
- Adds `all` query param for collections that will show results from all envs instead of specific ones, default no query param is still `production`.
- Adds new test after this new change to check that all environments are being fetched when using `all` query param after fetching all collections.


NOTE: `vocabularies` and `favourites` apply their fetching directly to the `widgets`, `layers` and `datasets` environments, and those three have already implemented `all` query param for their fetching.