### PR TITLE
feat: fix incorrect validation for collection creation

### DIFF
--- a/app/src/models/collection.model.js
+++ b/app/src/models/collection.model.js
@@ -3,6 +3,8 @@ const mongoosePaginate = require('mongoose-paginate');
 
 const { Schema } = mongoose;
 
+const { RESOURCES } = require('app.constants');
+
 const Collection = new Schema({
     name: { type: String, required: true, trim: true },
     application: {
@@ -15,7 +17,9 @@ const Collection = new Schema({
     resources: [{
         _id: false,
         id: { type: String, required: true, trim: true },
-        type: { type: String, required: true, trim: true }
+        type: {
+            type: String, required: true, trim: true, enum: RESOURCES
+        }
     }]
 });
 Collection.plugin(mongoosePaginate);

--- a/app/src/validators/collection.validator.js
+++ b/app/src/validators/collection.validator.js
@@ -1,6 +1,7 @@
 const logger = require('logger');
 const ErrorSerializer = require('serializers/error.serializer');
 const CollectionModel = require('models/collection.model');
+const { RESOURCES } = require('app.constants');
 
 class CollectionValidator {
 
@@ -11,10 +12,14 @@ class CollectionValidator {
         ctx.checkBody('application').optional().toLow();
         ctx.checkBody('resources').optional().check((data) => {
 
-            logger.debug('entering validation', data.resources);
-            if (data.resources) {
-                for (let i = 0; i < data.resources.length; i++) {
-                    if (!data.resources[i].type || !data.resources[i].id) { return false; }
+            logger.debug('entering validation', data);
+            if (data) {
+                for (let i = 0; i < data.length; i++) {
+                    if (
+                        !data[i].type
+                        || !data[i].id
+                        || !RESOURCES.includes(data[i].type)
+                    ) { return false; }
                 }
             }
             return true;

--- a/app/test/e2e/collection/collection-create.spec.js
+++ b/app/test/e2e/collection/collection-create.spec.js
@@ -2,7 +2,7 @@ const nock = require('nock');
 const chai = require('chai');
 const Collection = require('models/collection.model');
 const { USERS } = require('../utils/test.constants');
-const { ensureCorrectError, mockGetUserFromToken } = require('../utils/helpers');
+const { ensureCorrectError, mockGetUserFromToken, getUUID } = require('../utils/helpers');
 
 const { getTestServer } = require('../utils/test-server');
 
@@ -77,15 +77,30 @@ describe('Create collections', () => {
             .send({
                 name: 'collection',
                 application: 'rw',
-                resource: {
+                resources: [{
+                    id: getUUID(),
                     type: 'collection'
-                }
+                }]
             });
 
-        response.status.should.equal(200);
-        response.body.data.attributes.name.should.equal('collection');
-        response.body.data.attributes.application.should.equal('rw');
-        response.body.data.attributes.should.have.property('env').and.equal('production');
+        response.status.should.equal(400);
+    });
+
+    it('Create a collection with no resource id but valid resource type should return a 400', async () => {
+        mockGetUserFromToken(USERS.USER);
+
+        const response = await requester
+            .post(`/api/v1/collection`)
+            .set('Authorization', `Bearer abcd`)
+            .send({
+                name: 'collection',
+                application: 'rw',
+                resources: [{
+                    type: 'dataset',
+                }]
+            });
+
+        response.status.should.equal(400);
     });
 
     afterEach(async () => {

--- a/app/test/e2e/collection/collection-update.spec.js
+++ b/app/test/e2e/collection/collection-update.spec.js
@@ -38,9 +38,10 @@ describe('Update collections', () => {
         ensureCorrectError(response.body, 'Unauthorized');
     });
 
-    it('Update a collection while being authenticated as a USER and the correct body fields should return a 200 (happy case)', async () => {
+    it('Update a collection while being authenticated as a USER and the correct body fields should return a 200 and update name and/or env (happy case)', async () => {
         mockGetUserFromToken(USERS.USER);
         const collection = await new Collection(createCollection({
+            name: 'name',
             application: 'rw',
             ownerId: USERS.USER.id
         })).save();


### PR DESCRIPTION
BEWARE: Probable BC in this pull request.

-Fixes incorrect validation when creating collections.
-Add tests that check correct validation for both type and id of resources inside collection.


NOTE: the `PATCH` route seems like does not update the actual document in the DB. Is this how it is supposed this should work?